### PR TITLE
Add possibility to work behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ os.environ['RESTAPI_USE_ARCPY'] = 'FALSE'
 import restapi
 ```
 
+You may also need to work behind a proxy (a "real" proxy as in requests module's "proxies" argument, not an arcgis proxy) ; in that case, you should also alter os.environ BEFORE importing restapi)
+
+```py
+import os
+os.environ['RESTAPI_USE_ARCPY'] = 'FALSE'
+os.environ['RESTAPI_PROXY_REQUESTS_PATH'] = "http://my/proxy.com:8080"
+
+# now import restapi
+import restapi
+```
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ os.environ['RESTAPI_USE_ARCPY'] = 'FALSE'
 import restapi
 ```
 
-You may also need to work behind a proxy (a "real" proxy as in requests module's "proxies" argument, not an arcgis proxy) ; in that case, you should also alter os.environ BEFORE importing restapi)
+You may also need to work behind a proxy (a "real" proxy as in requests module's "proxies" argument, not an arcgis proxy) ; in that case, you should also alter os.environ BEFORE importing restapi :
 
 ```py
 import os
@@ -41,8 +41,6 @@ os.environ['RESTAPI_PROXY_REQUESTS_PATH'] = "http://my/proxy.com:8080"
 # now import restapi
 import restapi
 ```
-
-
 
 
 ## Connecting to an ArcGIS Server

--- a/restapi/admin/__init__.py
+++ b/restapi/admin/__init__.py
@@ -24,6 +24,15 @@ BASE_PATTERN = '*:*/arcgis/*admin*'
 AGOL_ADMIN_BASE_PATTERN = 'http*://*/rest/admin/services*'
 VERBOSE = True
 
+try:
+    proxy_requests_path = os.environ['RESTAPI_PROXY_REQUESTS_PATH']
+    proxies_request = {'http':proxy_requests_path, 'https':proxy_requests_path}
+    import functools
+    requests.post = functools.partial(requests.post, proxies=proxies_request)
+    requests.get = functools.partial(requests.get, proxies=proxies_request)    
+except KeyError:
+    pass
+
 # VERBOSE is set to true by default, this will echo the status of all operations
 #  i.e. reporting an administrative change was successful.  To turn this off, simply
 #  change VERBOSE to False.  This can be done like this:

--- a/restapi/common_types.py
+++ b/restapi/common_types.py
@@ -12,6 +12,15 @@ import warnings
 from munch import munchify
 from . import projections
 
+try:
+    proxy_requests_path = os.environ['RESTAPI_PROXY_REQUESTS_PATH']
+    proxies_request = {'http':proxy_requests_path, 'https':proxy_requests_path}
+    import functools
+    requests.post = functools.partial(requests.post, proxies=proxies_request)
+    requests.get = functools.partial(requests.get, proxies=proxies_request)    
+except KeyError:
+    pass
+
 import six
 from six.moves import urllib, zip_longest
 

--- a/restapi/rest_utils.py
+++ b/restapi/rest_utils.py
@@ -1103,7 +1103,7 @@ class FeatureSetBase(JsonGetter, SpatialReferenceMixin, FieldsMixin):
         return bool(len(self))
 
     def __dir__(self):
-        return sorted(list(self.__class__.__dict__.keys()) + self.json.keys())
+        return sorted(list(self.__class__.__dict__.keys()) + list(self.json.keys()))
 
     def __repr__(self):
         return '<{} (count: {})>'.format(self.__class__.__name__, self.count)

--- a/restapi/rest_utils.py
+++ b/restapi/rest_utils.py
@@ -28,6 +28,15 @@ from six.moves import urllib
 # disable ssl warnings
 for warning in [SNIMissingWarning, InsecurePlatformWarning, InsecureRequestWarning]:
     disable_warnings(warning)
+    
+try:
+    proxy_requests_path = os.environ['RESTAPI_PROXY_REQUESTS_PATH']
+    proxies_request = {'http':proxy_requests_path, 'https':proxy_requests_path}
+    import functools
+    requests.post = functools.partial(requests.post, proxies=proxies_request)
+    requests.get = functools.partial(requests.get, proxies=proxies_request)    
+except KeyError:
+    pass
 
 class RestapiEncoder(json.JSONEncoder):
     """Encoder for restapi objects to make serializeable for JSON."""


### PR DESCRIPTION
This request is meant to allow for web connections behind a proxy (as I'm forced to do at my office).

I'm quite aware this is quite a clumsy attempt to revert to environment variables, but this seemed to be the easiest way : there is already a "proxy" argument defined in the module, regarding arcpy's internal (?) proxies... 

It was either that or rewriting long parts of the module and losing the compatibility of previously written scripts.

It seems to do the job anyway...