### PR TITLE
Update dir method for python 3 compatibility

### DIFF
--- a/restapi/rest_utils.py
+++ b/restapi/rest_utils.py
@@ -1094,7 +1094,7 @@ class FeatureSetBase(JsonGetter, SpatialReferenceMixin, FieldsMixin):
         return bool(len(self))
 
     def __dir__(self):
-        return sorted(list(self.__class__.__dict__.keys()) + self.json.keys())
+        return sorted(list(self.__class__.__dict__.keys()) + list(self.json.keys()))
 
     def __repr__(self):
         return '<{} (count: {})>'.format(self.__class__.__name__, self.count)


### PR DESCRIPTION
Previous code would raise TypeError : canonly concatenate list (not "dict_keys") to list