### PR TITLE
Fix instance of no type for shape

### DIFF
--- a/restapi/shapefile.py
+++ b/restapi/shapefile.py
@@ -266,6 +266,10 @@ class Shape(object):
         # create empty shape
         shape = Shape()
         # set shapeType
+        # If no type assume Point with x and y keys
+        if not "type" in geoj:
+            geoj["type"] = "Point"
+            geoj['coordinates'] = [geoj['x'], geoj['y']]
         geojType = geoj["type"] if geoj else "Null"
         if geojType == "Null":
             shapeType = NULL


### PR DESCRIPTION
For a map server I've been using this for (https://maps.six.nsw.gov.au/arcgis/rest/services/public/Valuation/MapServer/) points are listed as x and y keys rather than having a type key with a single coordinate. This changes coerces x and y keys into a coordinate point and adds the "Point" type so it fits cleanly into further logic.