### PR TITLE
Fix bug where fields is ignored if exceed_limit is True

### DIFF
--- a/restapi/common_types.py
+++ b/restapi/common_types.py
@@ -1757,7 +1757,9 @@ class MapServiceLayer(RESTEndpoint, SpatialReferenceMixin, FieldsMixin):
             if isinstance(records, int) and records > max_recs:
                 exceed_limit = True
             if exceed_limit:
-                for i, result in enumerate(self.query_in_chunks(records=records, **params)):
+                # for i, result in enumerate(self.query_in_chunks(records=records, **params)):
+                for i, result in enumerate(self.query_in_chunks(records=records, where=where,
+                                                                fields=fields, f=f, **kwargs)):
                     if i < 1:
                         server_response = result
                     else:

--- a/restapi/common_types.py
+++ b/restapi/common_types.py
@@ -1757,7 +1757,6 @@ class MapServiceLayer(RESTEndpoint, SpatialReferenceMixin, FieldsMixin):
             if isinstance(records, int) and records > max_recs:
                 exceed_limit = True
             if exceed_limit:
-                # for i, result in enumerate(self.query_in_chunks(records=records, **params)):
                 for i, result in enumerate(self.query_in_chunks(records=records, where=where,
                                                                 fields=fields, f=f, **kwargs)):
                     if i < 1:


### PR DESCRIPTION
This fixes #55.

Before the fix the `fields` was ignored when `exceed_limit` was True, e.g.:

```
import restapi

rest_url = 'https://sampleserver6.arcgisonline.com/arcgis/rest/services'
ags = restapi.ArcServer(rest_url)
usa = ags.getService('USA') #/USA/MapServer -> restapi.common_types.MapService
cities = usa.layer('Cities') # or can use layer id: usa.layer(0)

where = "st = 'CA' and pop2000 > 100000"

featureSet = cities.query(where=where, fields=["areaname", "capital"],
                          exceed_limit=True)
print(featureSet[0]["properties"])
# {
#   "areaname": "Anaheim",
#   "capital": "N",
#   "class": "city",
#   "objectid": 169,
#   "pop2000": 328014,
#   "st": "CA"
# }
```

after the fix:

```
featureSet = cities.query(where=where, fields=["areaname", "capital"],
                          exceed_limit=True)
print(featureSet[0]["properties"])
# {
#   "areaname": "Anaheim",
#   "capital": "N"
# }
```
