### PR TITLE
[Fix] UnboundLocalError: cannot access local variable 'endpt' where it is not associated with a value

### DIFF
--- a/restapi/common_types.py
+++ b/restapi/common_types.py
@@ -1432,6 +1432,7 @@ class ArcServer(RESTEndpoint):
             except Exception as e:
                 if getattr(e, 'code', None) in AuthExceptionCodes and ignore_folder_auth:
                     warnings.warn('Authentation Error for folder {}: {}{}'.format(f, os.linesep,  e))
+                    continue
                 else:
                     raise
             services = []

--- a/restapi/common_types.py
+++ b/restapi/common_types.py
@@ -1353,6 +1353,7 @@ class ArcServer(RESTEndpoint):
             except Exception as e:
                 if getattr(e, 'code', None) in AuthExceptionCodes and ignore_folder_auth:
                     warnings.warn('Authentation Error for folder {}: {}{}'.format(s, os.linesep,  e))
+                    continue
                 else:
                     raise
             for serv in resp[SERVICES]:


### PR DESCRIPTION
When using an ArcGIS Server without credentials, and which has services that require credentials, functions `ags.walk` and `ags.list_services()` do not work correctly.

The code enters the `except` and does not create the `endpt` object, breaking in the `for`

```python
            try:
                endpt = self.request(new)
            except Exception as e:
                if getattr(e, 'code', None) in AuthExceptionCodes and ignore_folder_auth:
                    warnings.warn('Authentation Error for folder {}: {}{}'.format(f, os.linesep,  e))
                else:
                    raise
            services = []
            for serv in endpt[SERVICES]:
                qualified_service = '/'.join([serv[NAME], serv[TYPE]])
                full_service_url = '/'.join([self.url, qualified_service])
                services.append(qualified_service)
                self.service_cache.append(full_service_url)
            yield (f, services)
```

<br>

To adjust, I just added a `continue`, which allows me to receive an alert and continue to the next service, without "breaking" the application.


<br>


--------

The problem can be observed with this code below.

````python
import requests
import restapi


session = requests.Session()
client = restapi.RequestClient(session)
restapi.set_request_client(client)


url = 'https://mapas.agenciapcj.org.br/arcgis/rest/services'

# Connect to restapi.ArcServer instance
ags = restapi.ArcServer(url)

ags.list_services()


# walk thru directories
for root, services in ags.walk(ignore_folder_auth=True):
    print(f'Folder: {root}')
    print(f'Services: {services}')
````

<br>

The problem echoes a comment I made years ago [issue #36](https://github.com/Bolton-and-Menk-GIS/restapi/issues/36#issuecomment-1286015760).